### PR TITLE
Add client_max_body_size to 10M to upload pdf more than 2MB

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -35,4 +35,5 @@ http {
 
   include /etc/nginx/conf.d/*.conf;
   open_file_cache max=100;
+  client_max_body_size 10M;
 }


### PR DESCRIPTION
Add client_max_body_size to 10M to upload pdf more than 2MB